### PR TITLE
feat: speed-up form type resolving

### DIFF
--- a/src/Exception/MissingFormTypeAttributeException.php
+++ b/src/Exception/MissingFormTypeAttributeException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RequestDtoResolver\Exception;
+
+use Exception;
+
+final class MissingFormTypeAttributeException extends Exception
+{
+    public function __construct(string $className)
+    {
+        parent::__construct(sprintf('Missing #[FormType] attribute in class %s', $className));
+    }
+}

--- a/tests/Fixture/Controller.php
+++ b/tests/Fixture/Controller.php
@@ -6,9 +6,9 @@ namespace RequestDtoResolver\Tests\Fixture;
 
 use RequestDtoResolver\Attribute\FormType;
 
-class TestController
+class Controller
 {
-    #[FormType(class: TestForm::class)]
+    #[FormType(class: Form::class)]
     public function __invoke()
     {
     }

--- a/tests/Fixture/Form.php
+++ b/tests/Fixture/Form.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints as Assert;
 
-class TestForm extends AbstractType
+class Form extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
@@ -34,7 +34,7 @@ class TestForm extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'data_class' => TestDto::class
+            'data_class' => TargetDto::class
         ]);
     }
 }

--- a/tests/Fixture/TargetDto.php
+++ b/tests/Fixture/TargetDto.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace RequestDtoResolver\Tests\Fixture;
 
-class TestDto implements TargetDtoInterface
+class TargetDto implements TargetDtoInterface
 {
     public string $foo;
 

--- a/tests/Fixture/TargetDtoAsForm.php
+++ b/tests/Fixture/TargetDtoAsForm.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RequestDtoResolver\Tests\Fixture;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class TargetDtoAsForm extends Form implements TargetDtoInterface
+{
+    public string $foo;
+
+    public string $bar;
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => static::class
+        ]);
+    }
+}

--- a/tests/Integration/Resolver/RequestDtoResolverTest.php
+++ b/tests/Integration/Resolver/RequestDtoResolverTest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace RequestDtoResolver\Tests\Integration\Resolver;
 
 use RequestDtoResolver\Exception\InvalidParamsDtoException;
-use RequestDtoResolver\Tests\Fixture\TestDto;
-use RequestDtoResolver\Tests\Fixture\TargetDtoInterface;
+use RequestDtoResolver\Exception\MissingFormTypeAttributeException;
 use RequestDtoResolver\Resolver\RequestDtoResolver;
 use RequestDtoResolver\Tests\AbstractKernelTestCase;
-use RequestDtoResolver\Tests\Fixture\TestController;
+use RequestDtoResolver\Tests\Fixture\Controller;
+use RequestDtoResolver\Tests\Fixture\TargetDto;
+use RequestDtoResolver\Tests\Fixture\TargetDtoAsForm;
+use RequestDtoResolver\Tests\Fixture\TargetDtoInterface;
+use stdClass;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
@@ -25,10 +28,10 @@ class RequestDtoResolverTest extends AbstractKernelTestCase
     public function testResolve(): void
     {
         $argumentMock = $this->createMock(ArgumentMetadata::class);
-        $argumentMock->method('getType')->willReturn(TestDto::class);
+        $argumentMock->method('getType')->willReturn(TargetDto::class);
 
         $request = new Request();
-        $request->attributes->set('_controller', TestController::class);
+        $request->attributes->set('_controller', Controller::class);
         $request->request->set('foo', 'abc');
         $request->request->set('bar', 'def');
 
@@ -37,17 +40,90 @@ class RequestDtoResolverTest extends AbstractKernelTestCase
         $this->assertInstanceOf(TargetDtoInterface::class, $resolved[0]);
     }
 
-    public function testResolveException(): void
+    public function testInvalidParamsDtoException(): void
     {
         $argumentMock = $this->createMock(ArgumentMetadata::class);
-        $argumentMock->method('getType')->willReturn(TestDto::class);
+        $argumentMock->method('getType')->willReturn(TargetDto::class);
 
         $request = new Request();
-        $request->attributes->set('_controller', TestController::class);
+        $request->attributes->set('_controller', Controller::class);
         $request->request->set('foo', 5);
         $request->request->set('bar', false);
 
         $this->expectException(InvalidParamsDtoException::class);
         $this->requestDtoResolver->resolve($request, $argumentMock);
+    }
+
+    public function testMissingFormTypeAttributeException(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(TargetDto::class);
+
+        $controllerWithoutFormType = new class {
+            public function __invoke()
+            {
+            }
+        };
+
+        $request = new Request();
+        $request->attributes->set('_controller', get_class($controllerWithoutFormType));
+
+        $this->expectException(MissingFormTypeAttributeException::class);
+        $this->requestDtoResolver->resolve($request, $argumentMock);
+    }
+
+    public function testReturnsEmptyArrayForNullType(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(null);
+
+        $request = new Request();
+
+        $resolved = $this->requestDtoResolver->resolve($request, $argumentMock);
+
+        $this->assertSame([], $resolved);
+    }
+
+    public function testReturnsEmptyArrayForNonTargetDtoInterface(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(stdClass::class);
+
+        $request = new Request();
+
+        $resolved = $this->requestDtoResolver->resolve($request, $argumentMock);
+
+        $this->assertSame([], $resolved);
+    }
+
+    public function testParamsFallbackToHeaders(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(TargetDto::class);
+
+        $request = new Request();
+        $request->attributes->set('_controller', Controller::class);
+        $request->request->set('foo', null);
+        $request->request->set('bar', 'abc');
+        $request->headers->set('foo', 'headerValue');
+
+        $resolved = $this->requestDtoResolver->resolve($request, $argumentMock);
+
+        $this->assertSame('headerValue', $resolved[0]->foo);
+    }
+
+    public function testTargetDtoAsForm(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(TargetDtoAsForm::class);
+
+        $request = new Request();
+        $request->attributes->set('_controller', Controller::class);
+        $request->request->set('foo', 'abc');
+        $request->request->set('bar', 'def');
+
+        $resolved = $this->requestDtoResolver->resolve($request, $argumentMock);
+
+        $this->assertInstanceOf(TargetDtoInterface::class, $resolved[0]);
     }
 }


### PR DESCRIPTION
## Speed up form type resolving

First, trying to get form type from controller argument if it extends form abstract type (for example when the form file is the target DTO).

Else, fall back #[FormType] argument of controller action.