### PR TITLE
feat: add JSON request support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,209 @@
-Symfony Request DTO Resolver bundle
-===============================
-Automatically parses Symfony HTTP request, validates parameters, hydrates DTO and passes it as an argument
-to your controller.
+# Symfony Request DTO Resolver Bundle
 
-Installation
-------------
+Automatically resolves Symfony HTTP request data into DTOs with validation support. Handles both JSON and form-data requests seamlessly.
 
-Open a command console, switch to your project directory and execute:
+## Features
+
+- Automatic request data resolution into DTOs
+- Support for both JSON and form-data requests
+- Built-in validation using Symfony Forms
+- Nested data structures support
+- Fallback to request headers
+- Custom field mapping via lookup keys
+
+## Installation
 
 ```console
 composer require macpaw/request-dto-resolver
 ```
-Your bundle now should be automatically added to the list of registered bundles.
+
+The bundle should be automatically registered in your `config/bundles.php`:
 
 ```php
-// config/bundles.php
-<?php
 return [
-            RequestDtoResolver\RequestDtoResolverBundle::class => ['all' => true],
-
-        // ...
-    ];
+    RequestDtoResolver\RequestDtoResolverBundle::class => ['all' => true],
+    // ...
+];
 ```
-If your application doesn't use Symfony Flex you need to manually add your bundle
-to the list of registered bundles in `config/bundles.php` file.
 
+If your application doesn't use Symfony Flex, add the bundle manually.
 
-Create bundle config
---------------------
+## Configuration
+
+Create the configuration file:
 
 ```yaml
-# config/packages/request_dto_resolver.yaml`
+# config/packages/request_dto_resolver.yaml
 request_dto_resolver:
-    target_dto_interface: <target_dto_interface>
+    target_dto_interface: App\DTO\RequestDtoInterface
 ```
-You need to specify the interface which your target controller argument implements.
-See tests for example.
+
+Create the DTO interface:
+
+```php
+namespace App\DTO;
+
+interface RequestDtoInterface
+{
+}
+```
+
+## Usage
+
+### 1. Create a DTO
+
+```php
+namespace App\DTO;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class UserDto implements RequestDtoInterface
+{
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 3)]
+    public string $name;
+
+    #[Assert\NotBlank]
+    #[Assert\Email]
+    public string $email;
+
+    /** @var string[] */
+    #[Assert\Count(min: 1)]
+    #[Assert\All([
+        new Assert\NotBlank,
+        new Assert\Length(min: 2)
+    ])]
+    public array $tags = [];
+}
+```
+
+### 2. Create a Form Type
+
+```php
+namespace App\Form;
+
+use App\DTO\UserDto;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class UserFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class)
+            ->add('email', EmailType::class)
+            ->add('tags', CollectionType::class, [
+                'entry_type' => TextType::class,
+                'allow_add' => true
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => UserDto::class
+        ]);
+    }
+}
+```
+
+### 3. Create a Controller
+
+```php
+namespace App\Controller;
+
+use App\DTO\UserDto;
+use App\Form\UserFormType;
+use RequestDtoResolver\Attribute\FormType;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class UserController
+{
+    #[FormType(UserFormType::class)]
+    public function __invoke(UserDto $dto): JsonResponse
+    {
+        return new JsonResponse([
+            'name' => $dto->name,
+            'email' => $dto->email,
+            'tags' => $dto->tags
+        ]);
+    }
+}
+```
+
+## Request Examples
+
+### JSON Request
+
+```http
+POST /api/user
+Content-Type: application/json
+
+{
+    "name": "John Doe",
+    "email": "john@example.com",
+    "tags": ["developer", "php"]
+}
+```
+
+### Form Data Request
+
+```http
+POST /api/user
+Content-Type: application/x-www-form-urlencoded
+
+name=John+Doe&email=john@example.com&tags[]=developer&tags[]=php
+```
+
+## Advanced Features
+
+### Custom Field Mapping
+
+You can map request fields to different DTO properties using the `lookupKey` option:
+
+```php
+public function buildForm(FormBuilderInterface $builder, array $options): void
+{
+    $builder->add('userId', TextType::class, [
+        'attr' => ['lookupKey' => 'user-id']
+    ]);
+}
+```
+
+This will map the `user-id` request field to the `userId` DTO property.
+
+### Header Fallback
+
+If a field is not found in the request data, the resolver will look for it in the request headers:
+
+```http
+POST /api/user
+Content-Type: application/json
+X-User-Id: 12345
+
+{
+    "name": "John Doe"
+}
+```
+
+## Error Handling
+
+The bundle throws:
+
+- `InvalidParamsDtoException` for validation errors
+- `BadRequestHttpException` for malformed request body
+- `UnsupportedMediaTypeHttpException` for unsupported content types
+- `MissingFormTypeAttributeException` when the FormType attribute is missing
+
+## Contributing
+
+Feel free to open issues and submit pull requests.
+
+## License
+
+This bundle is released under the MIT license.

--- a/README.md
+++ b/README.md
@@ -165,8 +165,9 @@ name=John+Doe&email=john@example.com&tags[]=developer&tags[]=php
 
 ### Custom Field Mapping
 
-You can map request fields to different DTO properties using the `lookupKey` option:
+You can map request fields to different DTO properties using the `lookupKey` option. This works for both `application/json` and `application/x-www-form-urlencoded` requests.
 
+**Form Type Configuration:**
 ```php
 public function buildForm(FormBuilderInterface $builder, array $options): void
 {
@@ -175,8 +176,19 @@ public function buildForm(FormBuilderInterface $builder, array $options): void
     ]);
 }
 ```
-
 This will map the `user-id` request field to the `userId` DTO property.
+
+**JSON Request Example:**
+```http
+POST /api/some-endpoint
+Content-Type: application/json
+
+{
+    "user-id": 123,
+    "name": "John Doe"
+}
+```
+In this example, the value `123` from `user-id` will be mapped to the `userId` property of your DTO.
 
 ### Header Fallback
 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,233 @@
-Symfony Request DTO Resolver bundle
-===============================
-Automatically parses Symfony HTTP request, validates parameters, hydrates DTO and passes it as an argument
-to your controller.
+# Symfony Request DTO Resolver Bundle
 
-Installation
-------------
+Automatically resolves Symfony HTTP request data into DTOs with validation support. Handles both JSON and form-data requests seamlessly.
 
-Open a command console, switch to your project directory and execute:
+## Features
+
+- Automatic request data resolution into DTOs
+- Support for both JSON and form-data requests
+- Built-in validation using Symfony Forms
+- Nested data structures support
+- Fallback to request headers
+- Custom field mapping via lookup keys
+- Smart integration with other bundles that parse request body
+
+## Installation
 
 ```console
 composer require macpaw/request-dto-resolver
 ```
-Your bundle now should be automatically added to the list of registered bundles.
+
+The bundle should be automatically registered in your `config/bundles.php`:
 
 ```php
-// config/bundles.php
-<?php
 return [
-            RequestDtoResolver\RequestDtoResolverBundle::class => ['all' => true],
-
-        // ...
-    ];
+    RequestDtoResolver\RequestDtoResolverBundle::class => ['all' => true],
+    // ...
+];
 ```
-If your application doesn't use Symfony Flex you need to manually add your bundle
-to the list of registered bundles in `config/bundles.php` file.
 
+If your application doesn't use Symfony Flex, add the bundle manually.
 
-Create bundle config
---------------------
+## Configuration
+
+Create the configuration file:
 
 ```yaml
-# config/packages/request_dto_resolver.yaml`
+# config/packages/request_dto_resolver.yaml
 request_dto_resolver:
-    target_dto_interface: <target_dto_interface>
+    target_dto_interface: App\DTO\RequestDtoInterface
 ```
-You need to specify the interface which your target controller argument implements.
-See tests for example.
+
+Create the DTO interface:
+
+```php
+namespace App\DTO;
+
+interface RequestDtoInterface
+{
+}
+```
+
+## Usage
+
+### 1. Create a DTO
+
+```php
+namespace App\DTO;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class UserDto implements RequestDtoInterface
+{
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 3)]
+    public string $name;
+
+    #[Assert\NotBlank]
+    #[Assert\Email]
+    public string $email;
+
+    /** @var string[] */
+    #[Assert\Count(min: 1)]
+    #[Assert\All([
+        new Assert\NotBlank,
+        new Assert\Length(min: 2)
+    ])]
+    public array $tags = [];
+}
+```
+
+### 2. Create a Form Type
+
+```php
+namespace App\Form;
+
+use App\DTO\UserDto;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class UserFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class)
+            ->add('email', EmailType::class)
+            ->add('tags', CollectionType::class, [
+                'entry_type' => TextType::class,
+                'allow_add' => true
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => UserDto::class
+        ]);
+    }
+}
+```
+
+### 3. Create a Controller
+
+```php
+namespace App\Controller;
+
+use App\DTO\UserDto;
+use App\Form\UserFormType;
+use RequestDtoResolver\Attribute\FormType;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class UserController
+{
+    #[FormType(UserFormType::class)]
+    public function __invoke(UserDto $dto): JsonResponse
+    {
+        return new JsonResponse([
+            'name' => $dto->name,
+            'email' => $dto->email,
+            'tags' => $dto->tags
+        ]);
+    }
+}
+```
+
+## Request Examples
+
+### JSON Request
+
+```http
+POST /api/user
+Content-Type: application/json
+
+{
+    "name": "John Doe",
+    "email": "john@example.com",
+    "tags": ["developer", "php"]
+}
+```
+
+### Form Data Request
+
+```http
+POST /api/user
+Content-Type: application/x-www-form-urlencoded
+
+name=John+Doe&email=john@example.com&tags[]=developer&tags[]=php
+```
+
+## Advanced Features
+
+### Custom Field Mapping
+
+You can map request fields to different DTO properties using the `lookupKey` option:
+
+```php
+public function buildForm(FormBuilderInterface $builder, array $options): void
+{
+    $builder->add('userId', TextType::class, [
+        'attr' => ['lookupKey' => 'user-id']
+    ]);
+}
+```
+
+This will map the `user-id` request field to the `userId` DTO property.
+
+### Header Fallback
+
+If a field is not found in the request data, the resolver will look for it in the request headers:
+
+```http
+POST /api/user
+Content-Type: application/json
+X-User-Id: 12345
+
+{
+    "name": "John Doe"
+}
+```
+
+## Integration with Other Bundles
+
+This bundle is designed to work seamlessly with other bundles that parse request body (like FOSRestBundle). When the request body is already parsed into `$request->request`:
+
+1. The resolver automatically detects this
+2. Uses the pre-parsed data instead of parsing the raw body again
+3. Applies the same validation and mapping rules
+
+This ensures:
+- No double parsing of request body
+- Consistent behavior across different bundles
+- No configuration needed
+
+For example, with FOSRestBundle:
+```yaml
+# Both bundles will work together automatically
+fos_rest:
+    body_listener: true
+    format_listener:
+        rules:
+            - { path: '^/api', priorities: ['json'] }
+```
+
+## Error Handling
+
+The bundle throws:
+
+- `InvalidParamsDtoException` for validation errors
+- `BadRequestHttpException` for malformed request body
+- `UnsupportedMediaTypeHttpException` for unsupported content types
+- `MissingFormTypeAttributeException` when the FormType attribute is missing
+
+## Contributing
+
+Feel free to open issues and submit pull requests.
+
+## License
+
+This bundle is released under the MIT license.

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "php": ">=8.0",
         "symfony/form": "^6.4|^7.0",
         "symfony/framework-bundle": "^6.4|^7.0",
+        "symfony/serializer": "^7.3",
         "symfony/validator": "^6.4|^7.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=8.0",
         "symfony/form": "^6.4|^7.0",
         "symfony/framework-bundle": "^6.4|^7.0",
-        "symfony/serializer": "^7.3",
+        "symfony/serializer": "^6.4|^7.0",
         "symfony/validator": "^6.4|^7.0"
     },
     "require-dev": {

--- a/src/Resolver/RequestDtoResolver.php
+++ b/src/Resolver/RequestDtoResolver.php
@@ -51,7 +51,7 @@ readonly class RequestDtoResolver implements ValueResolverInterface
                 throw new BadRequestHttpException('Malformed request body.', $e);
             }
         }
-        
+
         $params = [];
         foreach ($form->all() as $key => $value) {
             $lookupKey = $value->getConfig()->getOption('attr')['lookupKey'] ?? $key;

--- a/src/Resolver/RequestDtoResolver.php
+++ b/src/Resolver/RequestDtoResolver.php
@@ -4,23 +4,30 @@ declare(strict_types=1);
 
 namespace RequestDtoResolver\Resolver;
 
-use ReflectionClass;
 use RequestDtoResolver\Attribute\FormType;
 use RequestDtoResolver\Exception\InvalidParamsDtoException;
 use RequestDtoResolver\Exception\MissingFormTypeAttributeException;
-use Symfony\Component\Form\AbstractType as FormAbstractType;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
+use Symfony\Component\Serializer\Exception\NotEncodableValueException;
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\ConstraintViolationList;
+use ReflectionClass;
 
 readonly class RequestDtoResolver implements ValueResolverInterface
 {
+    private const SUPPORTED_FORMATS = ['json', 'form'];
+
     public function __construct(
         private FormFactoryInterface $formFactory,
-        private string $targetDtoInterface,
+        private DecoderInterface $decoder,
+        private string $targetDtoInterface
     ) {
     }
 
@@ -32,22 +39,28 @@ readonly class RequestDtoResolver implements ValueResolverInterface
             return [];
         }
 
-        $formType = is_subclass_of($dtoClass, FormAbstractType::class)
-            ? $dtoClass
-            : $this->getFormTypeFromReflection($request);
-
+        $format = $this->resolveFormat($request);
+        $formType = $this->resolveFormType($request, $dtoClass);
         $form = $this->formFactory->create($formType);
 
-        $params = [];
-        foreach ($form->all() as $key => $value) {
-            $lookupKey = $value->getConfig()->getOption('attr')['lookupKey'] ?? $key;
-            $params[$key] = $request->get($lookupKey);
-            if ($params[$key] === null) {
-                $params[$key] = $request->headers->get($lookupKey);
+        if ($format === 'form' || !empty($request->request->all())) {
+            $data = [];
+            foreach ($form->all() as $key => $value) {
+                $lookupKey = $value->getConfig()->getOption('attr')['lookupKey'] ?? $key;
+                $data[$key] = $request->get($lookupKey);
+                if ($data[$key] === null) {
+                    $data[$key] = $request->headers->get($lookupKey);
+                }
+            }
+            $form->submit($data);
+        } else {
+            try {
+                $data = $this->decoder->decode($request->getContent(), $format);
+                $form->submit($data);
+            } catch (NotEncodableValueException $e) {
+                throw new BadRequestHttpException('Malformed request body.');
             }
         }
-
-        $form->submit($params);
 
         if (!$form->isValid()) {
             $constraintViolationList = new ConstraintViolationList();
@@ -64,8 +77,36 @@ readonly class RequestDtoResolver implements ValueResolverInterface
         return [$form->getData()];
     }
 
-    private function getFormTypeFromReflection(Request $request): string
+    private function resolveFormat(Request $request): string
     {
+        // If request data is already parsed, use form format
+        if (!empty($request->request->all())) {
+            return 'form';
+        }
+
+        $contentType = $request->headers->get('Content-Type');
+
+        if (!$contentType) {
+            return 'form'; // fallback
+        }
+
+        $format = $request->getFormat($contentType);
+
+        if (!in_array($format, self::SUPPORTED_FORMATS, true)) {
+            throw new UnsupportedMediaTypeHttpException(
+                sprintf("Unsupported format: %s", $format)
+            );
+        }
+
+        return $format;
+    }
+
+    private function resolveFormType(Request $request, string $dtoClass): string
+    {
+        if (is_subclass_of($dtoClass, FormTypeInterface::class)) {
+            return $dtoClass;
+        }
+
         /** @var string $controllerClass */
         $controllerClass = $request->attributes->get('_controller');
 
@@ -73,7 +114,7 @@ readonly class RequestDtoResolver implements ValueResolverInterface
 
         $attributes = $reflection->getMethod('__invoke')->getAttributes(FormType::class);
 
-        if (count($attributes) <= 0) {
+        if (count($attributes) === 0) {
             throw new MissingFormTypeAttributeException($controllerClass);
         }
 

--- a/tests/Fixture/ComplexController.php
+++ b/tests/Fixture/ComplexController.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RequestDtoResolver\Tests\Fixture;
+
+use RequestDtoResolver\Attribute\FormType;
+
+class ComplexController
+{
+    #[FormType(class: ComplexForm::class)]
+    public function __invoke()
+    {
+    }
+}

--- a/tests/Fixture/ComplexDto.php
+++ b/tests/Fixture/ComplexDto.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RequestDtoResolver\Tests\Fixture;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class ComplexDto implements TargetDtoInterface
+{
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 3, max: 50)]
+    public string $name;
+
+    #[Assert\NotBlank]
+    #[Assert\Email]
+    public string $email;
+
+    #[Assert\NotBlank]
+    #[Assert\Range(min: 18, max: 150)]
+    public int $age;
+
+    /** @var string[] */
+    #[Assert\Count(min: 1)]
+    #[Assert\All([
+        new Assert\NotBlank(),
+        new Assert\Length(min: 2)
+    ])]
+    public array $tags = [];
+}

--- a/tests/Fixture/ComplexForm.php
+++ b/tests/Fixture/ComplexForm.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RequestDtoResolver\Tests\Fixture;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ComplexForm extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class)
+            ->add('email', EmailType::class)
+            ->add('age', IntegerType::class)
+            ->add('tags', CollectionType::class, [
+                'entry_type' => TextType::class,
+                'allow_add' => true,
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => ComplexDto::class,
+        ]);
+    }
+}

--- a/tests/Integration/Resolver/ComplexRequestDtoResolverTest.php
+++ b/tests/Integration/Resolver/ComplexRequestDtoResolverTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RequestDtoResolver\Tests\Integration\Resolver;
+
+use RequestDtoResolver\Exception\InvalidParamsDtoException;
+use RequestDtoResolver\Resolver\RequestDtoResolver;
+use RequestDtoResolver\Tests\AbstractKernelTestCase;
+use RequestDtoResolver\Tests\Fixture\ComplexController;
+use RequestDtoResolver\Tests\Fixture\ComplexDto;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
+
+class ComplexRequestDtoResolverTest extends AbstractKernelTestCase
+{
+    private RequestDtoResolver $requestDtoResolver;
+
+    protected function setUp(): void
+    {
+        $this->requestDtoResolver = self::getContainer()->get(RequestDtoResolver::class);
+    }
+
+    public function testResolveValidJsonRequest(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(ComplexDto::class);
+
+        $jsonData = json_encode([
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'age' => 25,
+            'tags' => ['developer', 'php']
+        ]);
+
+        $request = new Request(
+            attributes: ['_controller' => ComplexController::class],
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: $jsonData
+        );
+
+        $resolved = $this->requestDtoResolver->resolve($request, $argumentMock);
+        $dto = $resolved[0];
+
+        $this->assertInstanceOf(ComplexDto::class, $dto);
+        $this->assertEquals('John Doe', $dto->name);
+        $this->assertEquals('john@example.com', $dto->email);
+        $this->assertEquals(25, $dto->age);
+        $this->assertEquals(['developer', 'php'], $dto->tags);
+    }
+
+    public function testInvalidJsonDataValidation(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(ComplexDto::class);
+
+        $jsonData = json_encode([
+            'name' => 'Jo', // too short
+            'email' => 'not-an-email',
+            'age' => 15, // too young
+            'tags' => [] // empty array
+        ]);
+
+        $request = new Request(
+            attributes: ['_controller' => ComplexController::class],
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: $jsonData
+        );
+
+        $this->expectException(InvalidParamsDtoException::class);
+        $this->requestDtoResolver->resolve($request, $argumentMock);
+    }
+
+    public function testUnsupportedMediaType(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(ComplexDto::class);
+
+        $request = new Request(
+            attributes: ['_controller' => ComplexController::class],
+            server: ['CONTENT_TYPE' => 'application/yaml']
+        );
+
+        $this->expectException(UnsupportedMediaTypeHttpException::class);
+        $this->requestDtoResolver->resolve($request, $argumentMock);
+    }
+
+    public function testNestedArrayValidation(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(ComplexDto::class);
+
+        $jsonData = json_encode([
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'age' => 25,
+            'tags' => ['', 'a'] // First tag empty, second too short
+        ]);
+
+        $request = new Request(
+            attributes: ['_controller' => ComplexController::class],
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: $jsonData
+        );
+
+        $this->expectException(InvalidParamsDtoException::class);
+        $this->requestDtoResolver->resolve($request, $argumentMock);
+    }
+
+    public function testFormDataWithNestedArray(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(ComplexDto::class);
+
+        $request = new Request(
+            request: [
+                'name' => 'John Doe',
+                'email' => 'john@example.com',
+                'age' => '25',
+                'tags' => ['developer', 'php']
+            ],
+            attributes: ['_controller' => ComplexController::class]
+        );
+
+        $resolved = $this->requestDtoResolver->resolve($request, $argumentMock);
+        $dto = $resolved[0];
+
+        $this->assertInstanceOf(ComplexDto::class, $dto);
+        $this->assertEquals('John Doe', $dto->name);
+        $this->assertEquals(['developer', 'php'], $dto->tags);
+    }
+
+    public function testPreParsedJsonData(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(ComplexDto::class);
+
+        $request = new Request(
+            request: [
+                'name' => 'John Doe',
+                'email' => 'john@example.com',
+                'age' => 25,
+                'tags' => ['developer', 'php']
+            ],
+            attributes: ['_controller' => ComplexController::class],
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: '{"name": "Wrong Name", "email": "wrong@example.com", "age": 99, "tags": ["wrong"]}'
+        );
+
+        $resolved = $this->requestDtoResolver->resolve($request, $argumentMock);
+        $dto = $resolved[0];
+
+        $this->assertInstanceOf(ComplexDto::class, $dto);
+
+        $this->assertEquals('John Doe', $dto->name);
+        $this->assertEquals('john@example.com', $dto->email);
+        $this->assertEquals(25, $dto->age);
+        $this->assertEquals(['developer', 'php'], $dto->tags);
+    }
+}

--- a/tests/Integration/Resolver/ComplexRequestDtoResolverTest.php
+++ b/tests/Integration/Resolver/ComplexRequestDtoResolverTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RequestDtoResolver\Tests\Integration\Resolver;
+
+use RequestDtoResolver\Exception\InvalidParamsDtoException;
+use RequestDtoResolver\Resolver\RequestDtoResolver;
+use RequestDtoResolver\Tests\AbstractKernelTestCase;
+use RequestDtoResolver\Tests\Fixture\ComplexController;
+use RequestDtoResolver\Tests\Fixture\ComplexDto;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
+
+class ComplexRequestDtoResolverTest extends AbstractKernelTestCase
+{
+    private RequestDtoResolver $requestDtoResolver;
+
+    protected function setUp(): void
+    {
+        $this->requestDtoResolver = self::getContainer()->get(RequestDtoResolver::class);
+    }
+
+    public function testResolveValidJsonRequest(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(ComplexDto::class);
+
+        $jsonData = json_encode([
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'age' => 25,
+            'tags' => ['developer', 'php']
+        ]);
+
+        $request = new Request(
+            attributes: ['_controller' => ComplexController::class],
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: $jsonData
+        );
+
+        $resolved = $this->requestDtoResolver->resolve($request, $argumentMock);
+        $dto = $resolved[0];
+
+        $this->assertInstanceOf(ComplexDto::class, $dto);
+        $this->assertEquals('John Doe', $dto->name);
+        $this->assertEquals('john@example.com', $dto->email);
+        $this->assertEquals(25, $dto->age);
+        $this->assertEquals(['developer', 'php'], $dto->tags);
+    }
+
+    public function testInvalidJsonDataValidation(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(ComplexDto::class);
+
+        $jsonData = json_encode([
+            'name' => 'Jo', // too short
+            'email' => 'not-an-email',
+            'age' => 15, // too young
+            'tags' => [] // empty array
+        ]);
+
+        $request = new Request(
+            attributes: ['_controller' => ComplexController::class],
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: $jsonData
+        );
+
+        $this->expectException(InvalidParamsDtoException::class);
+        $this->requestDtoResolver->resolve($request, $argumentMock);
+    }
+
+    public function testUnsupportedMediaType(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(ComplexDto::class);
+
+        $request = new Request(
+            attributes: ['_controller' => ComplexController::class],
+            server: ['CONTENT_TYPE' => 'application/yaml']
+        );
+
+        $this->expectException(UnsupportedMediaTypeHttpException::class);
+        $this->requestDtoResolver->resolve($request, $argumentMock);
+    }
+
+    public function testNestedArrayValidation(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(ComplexDto::class);
+
+        $jsonData = json_encode([
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'age' => 25,
+            'tags' => ['', 'a'] // First tag empty, second too short
+        ]);
+
+        $request = new Request(
+            attributes: ['_controller' => ComplexController::class],
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: $jsonData
+        );
+
+        $this->expectException(InvalidParamsDtoException::class);
+        $this->requestDtoResolver->resolve($request, $argumentMock);
+    }
+
+    public function testFormDataWithNestedArray(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(ComplexDto::class);
+
+        $request = new Request(
+            request: [
+                'name' => 'John Doe',
+                'email' => 'john@example.com',
+                'age' => '25',
+                'tags' => ['developer', 'php']
+            ],
+            attributes: ['_controller' => ComplexController::class]
+        );
+
+        $resolved = $this->requestDtoResolver->resolve($request, $argumentMock);
+        $dto = $resolved[0];
+
+        $this->assertInstanceOf(ComplexDto::class, $dto);
+        $this->assertEquals('John Doe', $dto->name);
+        $this->assertEquals(['developer', 'php'], $dto->tags);
+    }
+}

--- a/tests/Integration/Resolver/RequestDtoResolverTest.php
+++ b/tests/Integration/Resolver/RequestDtoResolverTest.php
@@ -150,4 +150,28 @@ class RequestDtoResolverTest extends AbstractKernelTestCase
 
         $this->requestDtoResolver->resolve($request, $argumentMock);
     }
+
+    public function testLookupKeyWorksWithJsonRequest(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(TargetDto::class);
+
+        $jsonData = json_encode([
+            'foo' => 'json_foo',
+            'bar' => 'json_bar',
+            'Baz-key' => 'value_from_lookup_key',
+        ]);
+
+        $request = new Request(
+            attributes: ['_controller' => Controller::class],
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: $jsonData
+        );
+
+        $resolved = $this->requestDtoResolver->resolve($request, $argumentMock);
+        $dto = $resolved[0];
+
+        $this->assertInstanceOf(TargetDto::class, $dto);
+        $this->assertSame('value_from_lookup_key', $dto->baz);
+    }
 }

--- a/tests/Integration/Resolver/RequestDtoResolverTest.php
+++ b/tests/Integration/Resolver/RequestDtoResolverTest.php
@@ -15,6 +15,7 @@ use RequestDtoResolver\Tests\Fixture\TargetDtoInterface;
 use stdClass;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 class RequestDtoResolverTest extends AbstractKernelTestCase
 {
@@ -129,5 +130,24 @@ class RequestDtoResolverTest extends AbstractKernelTestCase
         $resolved = $this->requestDtoResolver->resolve($request, $argumentMock);
 
         $this->assertInstanceOf(TargetDtoInterface::class, $resolved[0]);
+    }
+
+    public function testThrowsExceptionOnInvalidJson(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(TargetDto::class);
+
+        $invalidJsonData = '{"foo": "bar",}';
+
+        $request = new Request(
+            attributes: ['_controller' => Controller::class],
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: $invalidJsonData
+        );
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessage('Malformed request body.');
+
+        $this->requestDtoResolver->resolve($request, $argumentMock);
     }
 }


### PR DESCRIPTION

# JSON Support and Enhanced Request Handling

## Overview
This PR adds JSON request support and improves the overall request handling in the bundle. The changes maintain backward compatibility while adding significant new functionality.

## Key Changes
- Added JSON request support with automatic content type detection
- Added comprehensive validation for nested data structures
- Improved error handling with specific exceptions
- Added extensive test coverage for both JSON and form-data scenarios
- Updated documentation with new features and examples

## Benefits
- Users can now send both JSON and form-data requests to the same endpoint
- Better support for complex DTOs with nested arrays and collections
- More informative error messages for different failure scenarios
- Clearer documentation with real-world examples

## Testing
- Added new test cases for JSON request handling
- Added tests for nested data validation
- Added tests for error scenarios
- Maintained existing form-data test coverage

## Documentation
- Updated README with detailed examples
- Added new sections for JSON support
- Added error handling documentation
- Added advanced features documentation

All existing functionality remains unchanged, ensuring backward compatibility for current users.