### PR TITLE
Replaced removed Request::get(), set up the development environment 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 phpunit.xml
 var/
 vendor/
+coverage.xml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a PHP Symfony Bundle library (`macpaw/request-dto-resolver`). It has no runtime services, databases, or web servers — only CLI-based dev tools.
+
+### Quick reference
+
+Commands are defined in `composer.json` scripts section:
+
+| Task | Command |
+|---|---|
+| Install deps | `composer install` |
+| Tests | `composer phpunit` or `XDEBUG_MODE=coverage vendor/bin/phpunit` |
+| Lint (PHPCS) | `composer cs` |
+| Lint fix | `composer cs-fix` |
+| Static analysis | `composer phpstan` |
+| Validate | `composer validate` |
+
+### Gotchas
+
+- **Xdebug coverage mode**: PHPUnit warns if `XDEBUG_MODE=coverage` is not set. Use `XDEBUG_MODE=coverage vendor/bin/phpunit` to suppress the warning and generate `coverage.xml`.
+- **PHPStan ignored error**: `phpstan.neon` has an `ignoreErrors` entry for a Symfony `NodeDefinition::children()` error that no longer occurs. PHPStan will report "Ignored error pattern was not matched" (exit code 1). This is a pre-existing config issue.
+- **No composer.lock**: This repo does not commit `composer.lock` (standard for libraries). `composer install` runs `composer update` under the hood.
+- **Dependency conflict fixed**: The upstream `escapestudios/symfony2-coding-standard` `3.x-dev` now requires `phpcs ^4.0`, conflicting with the root `^3.0` constraint. The version was pinned to `^3.16` to resolve this.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,4 @@ Commands are defined in `composer.json` scripts section:
 ### Gotchas
 
 - **Xdebug coverage mode**: PHPUnit warns if `XDEBUG_MODE=coverage` is not set. Use `XDEBUG_MODE=coverage vendor/bin/phpunit` to suppress the warning and generate `coverage.xml`.
-- **PHPStan ignored error**: `phpstan.neon` has an `ignoreErrors` entry for a Symfony `NodeDefinition::children()` error that no longer occurs. PHPStan will report "Ignored error pattern was not matched" (exit code 1). This is a pre-existing config issue.
 - **No composer.lock**: This repo does not commit `composer.lock` (standard for libraries). `composer install` runs `composer update` under the hood.
-- **Dependency conflict fixed**: The upstream `escapestudios/symfony2-coding-standard` `3.x-dev` now requires `phpcs ^4.0`, conflicting with the root `^3.0` constraint. The version was pinned to `^3.16` to resolve this.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/validator": "^6.4|^7.0"
     },
     "require-dev": {
-        "escapestudios/symfony2-coding-standard": "3.x-dev",
+        "escapestudios/symfony2-coding-standard": "^3.16",
         "phpstan/phpstan": "^1.0",
         "phpunit/phpunit": "^10.0",
         "slevomat/coding-standard": "^8.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,8 +3,3 @@ parameters:
     paths:
         - src
         - tests
-    ignoreErrors:
-        -
-            message: '~Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children\(\).~'
-            count: 1
-            path: ./src/DependencyInjection

--- a/src/Resolver/RequestDtoResolver.php
+++ b/src/Resolver/RequestDtoResolver.php
@@ -62,10 +62,13 @@ class RequestDtoResolver implements ValueResolverInterface
             }
         }
 
+        $queryAll = $request->query->all();
+        $requestAll = $request->request->all();
+
         $params = [];
         foreach ($form->all() as $key => $value) {
             $lookupKey = $value->getConfig()->getOption('attr')['lookupKey'] ?? $key;
-            $params[$key] = $data[$lookupKey] ?? $request->get($lookupKey);
+            $params[$key] = $data[$lookupKey] ?? $queryAll[$lookupKey] ?? $requestAll[$lookupKey] ?? null;
             if ($params[$key] === null) {
                 $params[$key] = $request->headers->get($lookupKey);
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->

## Summary

Sets up the development environment and fixes Symfony 8.0 compatibility for the `macpaw/request-dto-resolver` Symfony Bundle.

### Changes

- **`composer.json`**: Pinned `escapestudios/symfony2-coding-standard` from `3.x-dev` to `^3.16` — the upstream `dev-master` now requires `phpcs ^4.0`, which conflicts with the root `^3.0` constraint.
- **`src/Resolver/RequestDtoResolver.php`**: Replaced removed `Request::get()` with explicit `$request->query->all()` / `$request->request->all()` lookups. Uses `all()` instead of `get()` to safely handle non-scalar values (arrays) that `InputBag::get()` rejects in Symfony 7+/8.0.
- **`phpstan.neon`**: Removed stale `ignoreErrors` entry for `NodeDefinition::children()` that no longer occurs.
- **`.gitignore`**: Added `coverage.xml` (generated test artifact).
- **`AGENTS.md`**: Added Cursor Cloud specific development instructions.

### Verification

| Check | Result |
|---|---|
| `composer validate` | ✅ Valid |
| `vendor/bin/phpcs` | ✅ 22/22 files pass |
| `vendor/bin/phpstan` | ✅ No errors |
| `vendor/bin/phpunit` | ✅ 22 tests, 50 assertions, 0 failures |

### Environment

- PHP 8.3.30 with Xdebug 3.5.0
- Composer 2.9.5



<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-636cad52-5015-4375-a041-596c4f2c1acf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-636cad52-5015-4375-a041-596c4f2c1acf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

