### PR TITLE
fix: restore route attribute lookup for DTO parameter resolution

### DIFF
--- a/src/Resolver/RequestDtoResolver.php
+++ b/src/Resolver/RequestDtoResolver.php
@@ -63,13 +63,10 @@ class RequestDtoResolver implements ValueResolverInterface
             }
         }
 
-        $queryAll = $request->query->all();
-        $requestAll = $request->request->all();
-
         $params = [];
         foreach ($form->all() as $key => $value) {
             $lookupKey = $value->getConfig()->getOption('attr')['lookupKey'] ?? $key;
-            $params[$key] = $data[$lookupKey] ?? $queryAll[$lookupKey] ?? $requestAll[$lookupKey] ?? null;
+            $params[$key] = $data[$lookupKey] ?? $this->getParameterFromRequestBags($request, $lookupKey);
             if ($params[$key] === null) {
                 $params[$key] = $request->headers->get($lookupKey);
             }
@@ -90,6 +87,26 @@ class RequestDtoResolver implements ValueResolverInterface
         }
 
         return [$form->getData()];
+    }
+
+    /**
+     * Mirrors deprecated Request::get() precedence: attributes (route params), then query, then body.
+     */
+    private function getParameterFromRequestBags(Request $request, string $lookupKey): mixed
+    {
+        if ($request->attributes->has($lookupKey)) {
+            return $request->attributes->get($lookupKey);
+        }
+
+        if ($request->query->has($lookupKey)) {
+            return $request->query->all()[$lookupKey];
+        }
+
+        if ($request->request->has($lookupKey)) {
+            return $request->request->all()[$lookupKey];
+        }
+
+        return null;
     }
 
     private function resolveFormat(Request $request): string

--- a/tests/Integration/Resolver/RequestDtoResolverTest.php
+++ b/tests/Integration/Resolver/RequestDtoResolverTest.php
@@ -266,4 +266,50 @@ class RequestDtoResolverTest extends AbstractKernelTestCase
         $this->assertSame('def', $dto->bar);
         $this->assertSame('ghi', $dto->baz);
     }
+
+    public function testResolvesParametersFromRouteAttributes(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(TargetDto::class);
+
+        $request = new Request(
+            attributes: [
+                '_controller' => Controller::class,
+                'foo' => 'from_route',
+                'bar' => 'from_route_bar',
+                'Baz-key' => 'from_route_baz',
+            ]
+        );
+
+        $resolved = $this->requestDtoResolver->resolve($request, $argumentMock);
+
+        $this->assertCount(1, $resolved);
+        /** @var TargetDto $dto */
+        $dto = $resolved[0];
+        $this->assertSame('from_route', $dto->foo);
+        $this->assertSame('from_route_bar', $dto->bar);
+        $this->assertSame('from_route_baz', $dto->baz);
+    }
+
+    public function testRouteAttributesTakePrecedenceOverQuery(): void
+    {
+        $argumentMock = $this->createMock(ArgumentMetadata::class);
+        $argumentMock->method('getType')->willReturn(TargetDto::class);
+
+        $request = new Request(
+            query: ['foo' => 'from_query', 'bar' => 'from_query', 'Baz-key' => 'from_query'],
+            attributes: [
+                '_controller' => Controller::class,
+                'foo' => 'from_route',
+            ]
+        );
+
+        $resolved = $this->requestDtoResolver->resolve($request, $argumentMock);
+
+        /** @var TargetDto $dto */
+        $dto = $resolved[0];
+        $this->assertSame('from_route', $dto->foo);
+        $this->assertSame('from_query', $dto->bar);
+        $this->assertSame('from_query', $dto->baz);
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`Request::get()` was replaced with only `query` and `request` bag lookups, which dropped **`attributes`** (where Symfony puts route/path parameters). DTO fields bound to `{id}`-style placeholders stopped resolving.

## Changes

- Restore the same precedence as deprecated `Request::get()`: **attributes → query → request**, using `has()` + `all()` so non-scalar body values are not forced through `InputBag::get()`.
- Integration tests: resolve from route attributes; route wins over query when both define the same key.

## Verification

- `vendor/bin/phpunit --no-coverage`
- `composer phpstan`
- `composer cs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbd42f3a-9d98-469c-8407-1b7000915e05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbd42f3a-9d98-469c-8407-1b7000915e05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

